### PR TITLE
Accept invalid/self-signed SSL certificates

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,13 @@ async fn takeover(hosts: Vec<String>, threads: usize) -> std::io::Result<()> {
 	let fetches = futures::stream::iter(
 		hosts.into_iter().map(|url| {
 			async move {
-				match reqwest::get(&url).await {
+				match reqwest::Client::builder()
+					.danger_accept_invalid_certs(true)
+					.build()
+					.unwrap()
+					.get(&url)
+					.send()
+					.await {
 					Ok(resp) => {
 						match resp.text().await {
 							Ok(text) => {


### PR DESCRIPTION
Hey @TheBinitGhimire,

Fix for: https://twitter.com/WHOISbinit/status/1357018526171553792

The issue was that the module `reqwest` doesn't allow connecting to a host with invalid/self-signed SSL certificates as it could introduce vulnerabilities (As mentioned in [docs](https://docs.rs/reqwest/0.9.9/reqwest/struct.ClientBuilder.html#method.danger_accept_invalid_certs)). But for use cases like this, we can override it with [`.danger_accept_invalid_certs()`](https://docs.rs/reqwest/0.9.9/reqwest/struct.ClientBuilder.html#method.danger_accept_invalid_certs).

I believe this solves the issue as a whole. I tested with a random IP I found with invalid certificate and it doesn't reach `Err(_)`.

![Screenshot from 2021-02-04 12-59-28](https://user-images.githubusercontent.com/26198477/106859815-964d6600-66e9-11eb-8d77-1580a0a072f2.png)

Also compiles without any warnings too. :+1: 

Nice project and Good Luck! :raised_hands::heart: