### PR TITLE
Add option to pass hostnames via STDIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ The installation walkthrough for **NtHiM** has been uploaded to YouTube, coverin
 | -h   | Display help related to usage!        | NtHiM -h                             |
 | -t   | Scan a single target!                 | NtHiM -t https://example.example.com |
 | -f   | Scan a list of targets from a file!   | NtHiM -f hostnames.txt               |
+| --stdin | Pass a list of targets via STDIN   | cat hostnames.txt | NtHiM --stdin    |
 | -c   | Number of Concurrent Threads!         | NtHiM -c 100 -f hostnames.txt        |
 | -s   | Timeout for connections (in seconds)! | NtHiM -s 4 -f hostnames.txt          |
 | -v   | Enable Verbose Mode!                  | NtHiM -v -f hostnames.txt            |
@@ -102,6 +103,12 @@ NtHiM -t https://example.example.com
 
 ```bash
 NtHiM -f hostnames.txt
+```
+
+### Use Case 3 (Multiple Targets via STDIN):
+
+```bash
+cat hostnames.txt | NtHiM --stdin
 ```
 
 ***

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -2,7 +2,7 @@ use clap::{App, AppSettings::ArgRequiredElseHelp, Arg, ArgMatches};
 
 pub fn _parse_args() -> ArgMatches {
     let stdin_arg = Arg::new("stdin")
-        .about("Read hosts from STDIN")
+        .help("Read hosts from STDIN")
         .long("stdin");
 
     App::new("NtHiM")

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -1,47 +1,52 @@
 use clap::{App, AppSettings::ArgRequiredElseHelp, Arg, ArgMatches};
 
 pub fn _parse_args() -> ArgMatches {
+    let stdin_arg = Arg::new("stdin")
+        .about("Read hosts from STDIN")
+        .long("stdin");
+
     App::new("NtHiM")
-		.version("0.1.4")
-		.author("Binit Ghimire <thebinitghimire@gmail.com>, Captain Nick Lucifer* <naryal2580@gmail.com>")
-		.about("Now, the Host is Mine! - Super Fast Sub-domain Takeover Detection!")
-		.setting(ArgRequiredElseHelp)
-		.args(&[
-			Arg::new("file")
-				.help("List of Hostnames separated with new line (\\n)!")
-				.short('f')
-				.long("file")
-				.takes_value(true),
-			Arg::new("target")
-				.help("Hostname with the protocol defined!")
-				.short('t')
-				.long("target")
-				.takes_value(true),
-			Arg::new("threads")
-				.help("Number of Concurrent Threads! (default: 10)")
-				.short('c')
-				.long("threads")
-				.takes_value(true),
-			Arg::new("timeout")
-				.help("Timeout for connections (in seconds)! (default: 5)")
-				.short('s')
-				.long("timeout")
-				.takes_value(true),
-			Arg::new("verbose")
-				.help("Enable Verbose Mode!")
-				.short('v')
-				.long("verbose")
-				.takes_value(false),
-			Arg::new("output")
-				.help("Write output to file!")
-				.short('o')
-				.long("output")
-				.takes_value(true),
-			Arg::new("update")
-				.help("Update signature cache!")
-				.short('u')
-				.long("update")
-				.takes_value(false),
-		])
-		.get_matches()
+        .version("0.1.4")
+        .author("Binit Ghimire <thebinitghimire@gmail.com>, Captain Nick Lucifer* <naryal2580@gmail.com>")
+        .about("Now, the Host is Mine! - Super Fast Sub-domain Takeover Detection!")
+        .setting(ArgRequiredElseHelp)
+        .args(&[
+            Arg::new("file")
+                .help("List of Hostnames separated with new line (\\n)!")
+                .short('f')
+                .long("file")
+                .takes_value(true),
+            Arg::new("target")
+                .help("Hostname with the protocol defined!")
+                .short('t')
+                .long("target")
+                .takes_value(true),
+            Arg::new("threads")
+                .help("Number of Concurrent Threads! (default: 10)")
+                .short('c')
+                .long("threads")
+                .takes_value(true),
+            Arg::new("timeout")
+                .help("Timeout for connections (in seconds)! (default: 5)")
+                .short('s')
+                .long("timeout")
+                .takes_value(true),
+            Arg::new("verbose")
+                .help("Enable Verbose Mode!")
+                .short('v')
+                .long("verbose")
+                .takes_value(false),
+            Arg::new("output")
+                .help("Write output to file!")
+                .short('o')
+                .long("output")
+                .takes_value(true),
+            Arg::new("update")
+                .help("Update signature cache!")
+                .short('u')
+                .long("update")
+                .takes_value(false),
+            stdin_arg,
+        ])
+        .get_matches()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use takeover::_takeover;
 
 use platform_dirs::AppDirs;
 use std::fs::remove_file;
-use std::{path::Path, process::exit, string::String};
+use std::{io::BufRead, path::Path, process::exit, string::String};
 
 fn main() -> std::io::Result<()> {
     let app_dirs = AppDirs::new(Some("NtHiM"), true).unwrap();
@@ -45,8 +45,20 @@ fn main() -> std::io::Result<()> {
         } else if args.is_present("target") {
             let _target = args.value_of("target").unwrap();
             hosts.push(_target.to_string());
+        } else {
+            let stdin = std::io::stdin();
+            for line in stdin.lock().lines() {
+                if let Ok(hostname) = line {
+                    hosts.push(hostname.trim().to_string());
+                }
+            }
         }
-        _takeover(hosts, _threads);
+        if hosts.is_empty() {
+            println!("No hosts provided. Exiting...");
+            exit(0);
+        } else {
+            _takeover(hosts, _threads);
+        }
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,9 @@ fn main() -> std::io::Result<()> {
         let hostnames = args.value_of("file").unwrap_or("hostnames.txt");
         hosts = _fileRead(hostnames.to_string());
     } else if args.is_present("target") {
+        let _target = args.value_of("target").unwrap();
+        hosts.push(_target.to_string());
+    } else if args.is_present("stdin"){
         let stdin = std::io::stdin();
         for line in stdin.lock().lines() {
             if let Ok(hostname) = line {

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,6 @@ fn main() -> std::io::Result<()> {
         println!("Please provide either a single hostname or a file containing a list of hostnames via STDIN.");
         exit(1);
     }
-    }
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ fn main() -> std::io::Result<()> {
         }
     }
 
-    if args.is_present("file") || args.is_present("target") {
+    if args.is_present("file") || args.is_present("target") || args.is_present("stdin") {
         if hosts.is_empty() {
             println!("No hosts provided. Exiting...");
             exit(0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,42 +23,44 @@ fn main() -> std::io::Result<()> {
         let signatures = _get_signatures_from_repo().unwrap();
         _cache_signatures(signatures);
     }
+
     if args.is_present("output") {
         let fileName = args.value_of("output").unwrap();
         if Path::new(&fileName).exists() {
             remove_file(fileName).unwrap();
         }
     }
+
     let _threads: usize = args
         .value_of("threads")
         .unwrap_or("10")
         .parse::<usize>()
         .unwrap_or(10);
-    if args.is_present("file") && args.is_present("target") {
-        println!("Please provide either a single hostname or a file containing list of hostnames rather than both!");
-        exit(1);
-    } else {
-        let mut hosts = Vec::<String>::new();
-        if args.is_present("file") {
-            let hostnames = args.value_of("file").unwrap_or("hostnames.txt");
-            hosts = _fileRead(hostnames.to_string());
-        } else if args.is_present("target") {
-            let _target = args.value_of("target").unwrap();
-            hosts.push(_target.to_string());
-        } else {
-            let stdin = std::io::stdin();
-            for line in stdin.lock().lines() {
-                if let Ok(hostname) = line {
-                    hosts.push(hostname.trim().to_string());
-                }
+
+    let mut hosts = Vec::<String>::new();
+    if args.is_present("file") {
+        let hostnames = args.value_of("file").unwrap_or("hostnames.txt");
+        hosts = _fileRead(hostnames.to_string());
+    } else if args.is_present("target") {
+        let stdin = std::io::stdin();
+        for line in stdin.lock().lines() {
+            if let Ok(hostname) = line {
+                hosts.push(hostname.trim().to_string());
             }
         }
+    }
+
+    if args.is_present("file") || args.is_present("target") {
         if hosts.is_empty() {
             println!("No hosts provided. Exiting...");
             exit(0);
         } else {
             _takeover(hosts, _threads);
         }
+    } else {
+        println!("Please provide either a single hostname or a file containing a list of hostnames via STDIN.");
+        exit(1);
+    }
     }
 
     Ok(())


### PR DESCRIPTION
I've implemented a feature to pass hostnames via STDIN. That makes it possible to use NtHiM in command chains, like for example `cat hosts.txt | httpx -silent | NtHiM --stdin`